### PR TITLE
Add error handling for document downloads

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,5 @@
+"""Agents package."""
+
+from .compliance_research_agent import ComplianceResearchAgent, DocumentDownloadError
+
+__all__ = ["ComplianceResearchAgent", "DocumentDownloadError"]

--- a/agents/compliance_research_agent.py
+++ b/agents/compliance_research_agent.py
@@ -1,0 +1,54 @@
+"""Compliance research agent utilities."""
+
+from __future__ import annotations
+
+import logging
+from urllib import request
+from urllib.error import HTTPError, URLError
+
+logger = logging.getLogger(__name__)
+
+
+class DocumentDownloadError(Exception):
+    """Raised when the agent fails to download a document."""
+
+
+class ComplianceResearchAgent:
+    """Agent capable of downloading compliance related documents."""
+
+    def download_document(self, url: str, dest_path: str) -> str:
+        """Download a document from ``url`` to ``dest_path``.
+
+        Parameters
+        ----------
+        url:
+            The URL of the document to download.
+        dest_path:
+            Local path where the downloaded content should be written.
+
+        Returns
+        -------
+        str
+            The destination path where the file was saved.
+
+        Raises
+        ------
+        DocumentDownloadError
+            If the document could not be downloaded due to network errors.
+        """
+
+        try:
+            with request.urlopen(url) as response:
+                content = response.read()
+        except HTTPError as e:
+            msg = f"HTTP error while downloading {url}: {e.code} {e.reason}"
+            logger.error(msg)
+            raise DocumentDownloadError(msg) from e
+        except URLError as e:
+            msg = f"URL error while downloading {url}: {e.reason}"
+            logger.error(msg)
+            raise DocumentDownloadError(msg) from e
+
+        with open(dest_path, "wb") as file:
+            file.write(content)
+        return dest_path

--- a/tests/test_compliance_research_agent.py
+++ b/tests/test_compliance_research_agent.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from urllib.error import HTTPError, URLError
+from urllib import request
+
+import pytest
+
+from agents.compliance_research_agent import (
+    ComplianceResearchAgent,
+    DocumentDownloadError,
+)
+
+
+def test_download_document_handles_urlerror(monkeypatch, tmp_path):
+    agent = ComplianceResearchAgent()
+    test_path = tmp_path / "doc.txt"
+
+    def fake_urlopen(url):
+        raise URLError("network unreachable")
+
+    monkeypatch.setattr(request, "urlopen", fake_urlopen)
+
+    with pytest.raises(DocumentDownloadError) as exc:
+        agent.download_document("http://example.com/doc.txt", str(test_path))
+
+    assert "network unreachable" in str(exc.value)
+    assert not test_path.exists()
+
+
+def test_download_document_handles_httperror(monkeypatch, tmp_path):
+    agent = ComplianceResearchAgent()
+    test_path = tmp_path / "doc.txt"
+
+    def fake_urlopen(url):
+        raise HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+
+    monkeypatch.setattr(request, "urlopen", fake_urlopen)
+
+    with pytest.raises(DocumentDownloadError) as exc:
+        agent.download_document("http://example.com/missing.txt", str(test_path))
+
+    assert "HTTP error" in str(exc.value)
+    assert not test_path.exists()


### PR DESCRIPTION
## Summary
- implement `ComplianceResearchAgent.download_document` with HTTP/URL error handling and custom exception
- test failed download scenarios by monkeypatching `urllib.request.urlopen`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b96ac61a8832cb023fd534de363e9