### PR TITLE
refactor: centralize requirement model

### DIFF
--- a/agents/compliance_research_agent.py
+++ b/agents/compliance_research_agent.py
@@ -6,6 +6,8 @@ import logging
 from urllib import request
 from urllib.error import HTTPError, URLError
 
+from agents.models import Requirement
+
 logger = logging.getLogger(__name__)
 
 

--- a/agents/data_source_mapping_agent.py
+++ b/agents/data_source_mapping_agent.py
@@ -1,0 +1,9 @@
+"""Data source mapping agent utilities."""
+
+from agents.models import Requirement
+
+
+class DataSourceMappingAgent:
+    """Agent responsible for mapping data sources to requirements."""
+
+    pass

--- a/agents/models.py
+++ b/agents/models.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Requirement:
+    """Model representing a generic requirement."""
+    id: str
+    description: str


### PR DESCRIPTION
## Summary
- add shared `Requirement` dataclass in `agents.models`
- import `Requirement` into `compliance_research_agent`
- add `data_source_mapping_agent` stub that uses shared `Requirement`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b9b67bc0c832cb1456a96b55341ba