### PR TITLE
refactor: centralize requirement model

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,5 +1,6 @@
 """Agents package."""
 
 from .compliance_research_agent import ComplianceResearchAgent, DocumentDownloadError
+from .models import Requirement
 
-__all__ = ["ComplianceResearchAgent", "DocumentDownloadError"]
+__all__ = ["ComplianceResearchAgent", "DocumentDownloadError", "Requirement"]

--- a/agents/models.py
+++ b/agents/models.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Requirement:
+    """Represents a compliance requirement with an associated document."""
+
+    name: str
+    document_url: str
+    description: str = ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agents.models import Requirement
+
+
+@pytest.fixture
+def requirement_factory():
+    """Factory fixture for creating Requirement instances."""
+
+    def _factory(**kwargs):
+        defaults = {"name": "Test Requirement", "document_url": "http://example.com/doc.txt"}
+        defaults.update(kwargs)
+        return Requirement(**defaults)
+
+    return _factory

--- a/tests/test_compliance_research_agent.py
+++ b/tests/test_compliance_research_agent.py
@@ -14,8 +14,9 @@ from agents.compliance_research_agent import (
 )
 
 
-def test_download_document_handles_urlerror(monkeypatch, tmp_path):
+def test_download_document_handles_urlerror(monkeypatch, tmp_path, requirement_factory):
     agent = ComplianceResearchAgent()
+    requirement = requirement_factory(document_url="http://example.com/doc.txt")
     test_path = tmp_path / "doc.txt"
 
     def fake_urlopen(url):
@@ -24,14 +25,17 @@ def test_download_document_handles_urlerror(monkeypatch, tmp_path):
     monkeypatch.setattr(request, "urlopen", fake_urlopen)
 
     with pytest.raises(DocumentDownloadError) as exc:
-        agent.download_document("http://example.com/doc.txt", str(test_path))
+        agent.download_document(requirement.document_url, str(test_path))
 
     assert "network unreachable" in str(exc.value)
     assert not test_path.exists()
 
 
-def test_download_document_handles_httperror(monkeypatch, tmp_path):
+def test_download_document_handles_httperror(monkeypatch, tmp_path, requirement_factory):
     agent = ComplianceResearchAgent()
+    requirement = requirement_factory(
+        document_url="http://example.com/missing.txt"
+    )
     test_path = tmp_path / "doc.txt"
 
     def fake_urlopen(url):
@@ -40,7 +44,7 @@ def test_download_document_handles_httperror(monkeypatch, tmp_path):
     monkeypatch.setattr(request, "urlopen", fake_urlopen)
 
     with pytest.raises(DocumentDownloadError) as exc:
-        agent.download_document("http://example.com/missing.txt", str(test_path))
+        agent.download_document(requirement.document_url, str(test_path))
 
     assert "HTTP error" in str(exc.value)
     assert not test_path.exists()


### PR DESCRIPTION
## Summary
- add shared `Requirement` dataclass in `agents.models`
- expose `Requirement` in agents package
- use a `requirement_factory` fixture and update tests to rely on central model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b9b69d558832cbb65f4c47245ad7a