### PR TITLE
Add agent activity tracking and review page

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,5 +1,11 @@
 """Agents package."""
 
 from .compliance_research_agent import ComplianceResearchAgent, DocumentDownloadError
+from .agent_activity_tracker import AgentActivityTracker, ActivityRecord
 
-__all__ = ["ComplianceResearchAgent", "DocumentDownloadError"]
+__all__ = [
+    "ComplianceResearchAgent",
+    "DocumentDownloadError",
+    "AgentActivityTracker",
+    "ActivityRecord",
+]

--- a/agents/agent_activity_tracker.py
+++ b/agents/agent_activity_tracker.py
@@ -1,0 +1,68 @@
+"""Utilities for tracking and reviewing agent activity."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Dict, Optional
+
+
+@dataclass
+class ActivityRecord:
+    """Represents a single activity performed by an agent."""
+
+    agent: str
+    action: str
+    timestamp: datetime
+
+
+class AgentActivityTracker:
+    """In-memory tracker for agent actions.
+
+    The tracker keeps a simple list of :class:`ActivityRecord` instances.
+    It can be used by different agents to log what they have done and later
+    review the collected activities.
+    """
+
+    def __init__(self) -> None:
+        self._records: List[ActivityRecord] = []
+
+    def log(self, agent_name: str, action: str, *, timestamp: Optional[datetime] = None) -> ActivityRecord:
+        """Log an activity for the given agent.
+
+        Parameters
+        ----------
+        agent_name: str
+            Name of the agent performing the action.
+        action: str
+            Description of the action.
+        timestamp: datetime, optional
+            When the action occurred. Defaults to :func:`datetime.utcnow`.
+
+        Returns
+        -------
+        ActivityRecord
+            The record that was stored.
+        """
+        if timestamp is None:
+            timestamp = datetime.utcnow()
+        record = ActivityRecord(agent=agent_name, action=action, timestamp=timestamp)
+        self._records.append(record)
+        return record
+
+    def get_activity(self, agent_name: Optional[str] = None) -> List[ActivityRecord]:
+        """Return activity records.
+
+        Parameters
+        ----------
+        agent_name: str, optional
+            If provided, only activities for this agent are returned.
+
+        Returns
+        -------
+        List[ActivityRecord]
+            A list of activity records.
+        """
+        if agent_name is None:
+            return list(self._records)
+        return [r for r in self._records if r.agent == agent_name]

--- a/agents/agent_activity_tracker.py
+++ b/agents/agent_activity_tracker.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Dict, Optional
+from typing import List, Optional
 
 
 @dataclass
@@ -66,3 +66,7 @@ class AgentActivityTracker:
         if agent_name is None:
             return list(self._records)
         return [r for r in self._records if r.agent == agent_name]
+
+    def list_agents(self) -> List[str]:
+        """Return a sorted list of agents with recorded activity."""
+        return sorted({record.agent for record in self._records})

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import Audit from "./components/Pages/CreateGreenNFT/Audit.js";
 import Claim from "./components/Pages/CreateGreenNFT/Claim.js";
 import MyGreenNFTs from "./components/Pages/MyGreenNFTs/index.js";
 import GreenNFTMarketplace from "./components/Pages/GreenNFTMarketplace/index.js";
+import AgentActivity from "./components/Pages/AgentActivity/index.js";
 import ipfs from './components/ipfs/ipfsApi.js'
 
 import { Loader, Button, Card, Input, Heading, Table, Form, Flex, Box, Image } from 'rimble-ui';
@@ -116,7 +117,15 @@ class App extends Component {
     return (
       <div className={styles.wrapper}>
         <GreenNFTMarketplace />
-      </div>    
+      </div>
+    );
+  }
+
+  renderAgentActivity() {
+    return (
+      <div className={styles.wrapper}>
+        <AgentActivity />
+      </div>
     );
   }
 
@@ -129,6 +138,7 @@ class App extends Component {
           {this.state.route === 'audit' && this.renderAudit()}
           {this.state.route === 'my-green-nfts' && this.renderMyGreenNFTs()}
           {this.state.route === 'green-nft-marketplace' && this.renderGreenNFTMarketplace()}
+          {this.state.route === 'agent-activity' && this.renderAgentActivity()}
         <Footer />
       </div>
     );

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,6 +8,7 @@ import Claim from "./components/Pages/CreateGreenNFT/Claim.js";
 import MyGreenNFTs from "./components/Pages/MyGreenNFTs/index.js";
 import GreenNFTMarketplace from "./components/Pages/GreenNFTMarketplace/index.js";
 import AgentActivity from "./components/Pages/AgentActivity/index.js";
+import Agents from "./components/Pages/Agents/index.js";
 import ipfs from './components/ipfs/ipfsApi.js'
 
 import { Loader, Button, Card, Input, Heading, Table, Form, Flex, Box, Image } from 'rimble-ui';
@@ -129,6 +130,14 @@ class App extends Component {
     );
   }
 
+  renderAgents() {
+    return (
+      <div className={styles.wrapper}>
+        <Agents />
+      </div>
+    );
+  }
+
   render() {
     return (
       <div className={styles.App}>
@@ -139,6 +148,7 @@ class App extends Component {
           {this.state.route === 'my-green-nfts' && this.renderMyGreenNFTs()}
           {this.state.route === 'green-nft-marketplace' && this.renderGreenNFTMarketplace()}
           {this.state.route === 'agent-activity' && this.renderAgentActivity()}
+          {this.state.route === 'agents' && this.renderAgents()}
         <Footer />
       </div>
     );

--- a/frontend/src/components/Header/index.js
+++ b/frontend/src/components/Header/index.js
@@ -18,6 +18,7 @@ const Header = () => (
             <li><a href="/my-green-nfts" className={styles.link}> My Green NFTs</a></li>
 
             <li><a href="/green-nft-marketplace" className={styles.link}> MarketPlace</a></li>
+            <li><a href="/agent-activity" className={styles.link}> Agent Activity</a></li>
           </ul>
         </nav>
     </div>

--- a/frontend/src/components/Header/index.js
+++ b/frontend/src/components/Header/index.js
@@ -18,6 +18,7 @@ const Header = () => (
             <li><a href="/my-green-nfts" className={styles.link}> My Green NFTs</a></li>
 
             <li><a href="/green-nft-marketplace" className={styles.link}> MarketPlace</a></li>
+            <li><a href="/agents" className={styles.link}> Agents</a></li>
             <li><a href="/agent-activity" className={styles.link}> Agent Activity</a></li>
           </ul>
         </nav>

--- a/frontend/src/components/Pages/AgentActivity/index.js
+++ b/frontend/src/components/Pages/AgentActivity/index.js
@@ -1,46 +1,30 @@
-import React, { Component } from "react";
+import React from 'react';
 import { Table } from 'rimble-ui';
-
 import styles from '../../../App.module.scss';
+import { sampleActivities } from './sampleData';
 
-export default class AgentActivity extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            activities: [
-                {
-                    agent: 'ComplianceResearchAgent',
-                    action: 'Downloaded document',
-                    timestamp: '2024-01-01 12:00'
-                }
-            ]
-        };
-    }
+const AgentActivity = () => (
+  <div className={styles.wrapper}>
+    <h2>Agent Activity</h2>
+    <Table>
+      <thead>
+        <tr>
+          <th>Agent</th>
+          <th>Action</th>
+          <th>Timestamp</th>
+        </tr>
+      </thead>
+      <tbody>
+        {sampleActivities.map((act, idx) => (
+          <tr key={idx}>
+            <td>{act.agent}</td>
+            <td>{act.action}</td>
+            <td>{act.timestamp}</td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  </div>
+);
 
-    render() {
-        const { activities } = this.state;
-        return (
-            <div className={styles.wrapper}>
-                <h2>Agent Activity</h2>
-                <Table>
-                    <thead>
-                        <tr>
-                            <th>Agent</th>
-                            <th>Action</th>
-                            <th>Timestamp</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {activities.map((act, idx) => (
-                            <tr key={idx}>
-                                <td>{act.agent}</td>
-                                <td>{act.action}</td>
-                                <td>{act.timestamp}</td>
-                            </tr>
-                        ))}
-                    </tbody>
-                </Table>
-            </div>
-        );
-    }
-}
+export default AgentActivity;

--- a/frontend/src/components/Pages/AgentActivity/index.js
+++ b/frontend/src/components/Pages/AgentActivity/index.js
@@ -1,0 +1,46 @@
+import React, { Component } from "react";
+import { Table } from 'rimble-ui';
+
+import styles from '../../../App.module.scss';
+
+export default class AgentActivity extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            activities: [
+                {
+                    agent: 'ComplianceResearchAgent',
+                    action: 'Downloaded document',
+                    timestamp: '2024-01-01 12:00'
+                }
+            ]
+        };
+    }
+
+    render() {
+        const { activities } = this.state;
+        return (
+            <div className={styles.wrapper}>
+                <h2>Agent Activity</h2>
+                <Table>
+                    <thead>
+                        <tr>
+                            <th>Agent</th>
+                            <th>Action</th>
+                            <th>Timestamp</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {activities.map((act, idx) => (
+                            <tr key={idx}>
+                                <td>{act.agent}</td>
+                                <td>{act.action}</td>
+                                <td>{act.timestamp}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </Table>
+            </div>
+        );
+    }
+}

--- a/frontend/src/components/Pages/AgentActivity/sampleData.js
+++ b/frontend/src/components/Pages/AgentActivity/sampleData.js
@@ -1,0 +1,7 @@
+export const sampleActivities = [
+  {
+    agent: 'ComplianceResearchAgent',
+    action: 'Downloaded document',
+    timestamp: '2024-01-01 12:00'
+  }
+];

--- a/frontend/src/components/Pages/Agents/index.js
+++ b/frontend/src/components/Pages/Agents/index.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Table } from 'rimble-ui';
+import styles from '../../../App.module.scss';
+import { sampleActivities } from '../AgentActivity/sampleData';
+
+const Agents = () => {
+  const agents = Array.from(new Set(sampleActivities.map(act => act.agent)));
+  return (
+    <div className={styles.wrapper}>
+      <h2>Agents</h2>
+      <Table>
+        <thead>
+          <tr>
+            <th>Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          {agents.map((name, idx) => (
+            <tr key={idx}>
+              <td>{name}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  );
+};
+
+export default Agents;

--- a/tests/test_agent_activity_tracker.py
+++ b/tests/test_agent_activity_tracker.py
@@ -21,3 +21,12 @@ def test_log_and_retrieve_activity():
     agent_a_records = tracker.get_activity("agentA")
     assert len(agent_a_records) == 1
     assert agent_a_records[0].timestamp == ts
+
+
+def test_list_agents_returns_unique_sorted():
+    tracker = AgentActivityTracker()
+    tracker.log("B", "foo")
+    tracker.log("A", "bar")
+    tracker.log("A", "baz")
+
+    assert tracker.list_agents() == ["A", "B"]

--- a/tests/test_agent_activity_tracker.py
+++ b/tests/test_agent_activity_tracker.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+from datetime import datetime
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agents.agent_activity_tracker import AgentActivityTracker
+
+
+def test_log_and_retrieve_activity():
+    tracker = AgentActivityTracker()
+    ts = datetime(2024, 1, 1, 12, 0, 0)
+    tracker.log("agentA", "did something", timestamp=ts)
+    tracker.log("agentB", "did something else", timestamp=ts)
+
+    all_records = tracker.get_activity()
+    assert len(all_records) == 2
+    assert all_records[0].agent == "agentA"
+    assert all_records[0].action == "did something"
+
+    agent_a_records = tracker.get_activity("agentA")
+    assert len(agent_a_records) == 1
+    assert agent_a_records[0].timestamp == ts


### PR DESCRIPTION
## Summary
- Implement in-memory `AgentActivityTracker` for logging agent actions
- Provide React page and navigation to review agent activity
- Add unit tests for activity tracker

## Testing
- `pytest`
- `npm test` *(fails: react-app-rewired: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b9df13218832c891f28cc7835701a